### PR TITLE
Improved error return

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 *.config.js
 *.config.ts
-*.test.js
-*.test.ts
 dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
   ],
+  "rules": {
+    "object-curly-spacing": ["error", "always"]
+  },
   "parserOptions": {
     "sourceType": "module"
   }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 A npm package based on [Tesla Light Show](https://github.com/teslamotors/light-show) for validating FSEQ file compatability with Tesla vehicles.
 
 Contains the following modules:
+- cli tool (**dist/cjs/cli.js** )
 - a CommonJS (in **dist/cjs** folder)
 - ES Modules (in **dist/esm** folder)
 - bundled and minified UMD (in **dist/umd** folder)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "node tools/cleanup",
     "package": "npm run build && npm pack",
     "test": "jest --coverage --no-cache --runInBand",
-    "lint": "eslint src --fix"
+    "lint": "eslint src test --fix"
   },
   "publishConfig": {
     "access": "public"

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,8 +1,6 @@
 /**
- * Those are the possible types of errors which can be returned by the validator.
- * 
- * Implementation note: Don't change the mapping between error type and number, as this will lead to wrong mappings
- * for outside code using the validator and these error types.
+ * Types of errors that can be returned by the validator
+ * Note that the order of the enum MUST NOT be changed as changes would be backwards incompatible
  */
 export enum ErrorType {
   InputData = 0,
@@ -15,7 +13,7 @@ export enum ErrorType {
 
 /**
  * Validation result type
- * Validation result is considered valid if the errors list is empty, otherwise invalid.
+ * Validation result is considered valid if the errors array is empty, otherwise invalid.
  * Other fields, if available, are returned to aid in building detailed errors or descriptions
  * @typedef {Object} ValidationResults - creates a new type named 'ValidationResults'
  * @property {number} [frameCount=0] - number of frames

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,16 +1,17 @@
 export enum ValidationPart {
-  FileFormat = 0,
-  ChannelCount = 1,
-  FseqType = 2,
-  Duration = 3,
-  Memory = 4,
-};
+  InputData = 0,
+  FileFormat = 1,
+  ChannelCount = 2,
+  FseqType = 3,
+  Duration = 4,
+  Memory = 5,
+}
 
 export class ValidationCheckResults {
   isValid: boolean;
-  message: String;
+  message: string;
 
-  constructor(isValid: boolean, message: String) {
+  constructor(isValid: boolean, message: string) {
     this.isValid = isValid
     this.message = message
   }
@@ -52,9 +53,16 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
     stepTime: 0,
     results: [],
   }
+
+  const isValid = true
+  const isInvalid = false
+
   if(!data) {
-    console.error('An input type of ArrayBuffer or ArrayBufferLike must be provided!');
+    const message = 'An input type of ArrayBuffer or ArrayBufferLike must be provided!';
+    validationResult.results[ValidationPart.InputData] = new ValidationCheckResults(isInvalid, message)
     return validationResult;
+  } else {
+    validationResult.results[ValidationPart.InputData] = new ValidationCheckResults(isValid, "")
   }
 
   const MEMORY_LIMIT = 681;
@@ -74,9 +82,6 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   validationResult.stepTime = header.getUint8(18);
 
   const compressionType = header.getUint8(20);
-
-  const isValid = true
-  const isInvalid = false
 
   if(magic !== 'PSEQ' || start < 24 || validationResult.frameCount < 1 || validationResult.stepTime < 15 || minor !== 0 || major !== 2) {
     const message = 'Unknown file format, expected FSEQ v2.0'

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,3 +1,9 @@
+/**
+ * Those are the possible types of errors which can be returned by the validator.
+ * 
+ * Implementation note: Don't change the mapping between error type and number, as this will lead to wrong mappings
+ * for outside code using the validator and these error types.
+ */
 export enum ErrorType {
   InputData = 0,
   FileFormat = 1,

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -9,7 +9,7 @@ export enum ErrorType {
 
 /**
  * Validation result type
- * Validation result is considered valid if the errors list is undefined, otherwise invalid.
+ * Validation result is considered valid if the errors list is empty, otherwise invalid.
  * Other fields, if available, are returned to aid in building detailed errors or descriptions
  * @typedef {Object} ValidationResults - creates a new type named 'ValidationResults'
  * @property {number} [frameCount=0] - number of frames
@@ -17,7 +17,7 @@ export enum ErrorType {
  * @property {number} [duration=0] - duration in milliseconds
  * @property {number} [commandCount=0] - number of commands, maximum being 681. commandCount / 681 = memoryUsage
  * @property {number} [stepTime=0] - duration between frames
- * @property {ErrorType[] | undefined} [errors=undefined] - If any, the errors that were found. If it undefined, the validation result is valid.
+ * @property {ErrorType[]} [errors=[]] - If length > 0, contains the errors that were found. If it empty, the validation result is valid.
  */
  export type ValidationResults = {
   frameCount: number;
@@ -26,7 +26,7 @@ export enum ErrorType {
   commandCount: number;
   stepTime: number;
   channelCount: number;
-  errors: ErrorType[] | undefined;
+  errors: ErrorType[];
 };
 
 /**
@@ -46,7 +46,7 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   }
 
   if(!data) {
-    validationResult.errors!.push(ErrorType.InputData);
+    validationResult.errors.push(ErrorType.InputData);
     return validationResult;
   }
 
@@ -70,23 +70,23 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   const compressionType = header.getUint8(20);
 
   if(magic !== 'PSEQ' || start < 24 || validationResult.frameCount < 1 || validationResult.stepTime < 15 || minor !== 0 || major !== 2) {
-    validationResult.errors!.push(ErrorType.FileFormat);
+    validationResult.errors.push(ErrorType.FileFormat);
     return validationResult
   }
 
   if(chCount !== 48) {
-    validationResult.errors!.push(ErrorType.ChannelCount)
+    validationResult.errors.push(ErrorType.ChannelCount)
     return validationResult;
   }
 
   if(compressionType !== 0) {
-    validationResult.errors!.push(ErrorType.FseqType)
+    validationResult.errors.push(ErrorType.FseqType)
     return validationResult;
   }
 
   validationResult.duration = (validationResult.frameCount * validationResult.stepTime);
   if(validationResult.duration > 5 * 60 * 1000) {
-    validationResult.errors!.push(ErrorType.Duration)
+    validationResult.errors.push(ErrorType.Duration)
   }
 
   let prevLight: number[] = [];
@@ -144,12 +144,8 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   validationResult.memoryUsage = validationResult.commandCount / MEMORY_LIMIT;
 
   if(validationResult.memoryUsage > 1) {
-    validationResult.errors!.push(ErrorType.Memory)
+    validationResult.errors.push(ErrorType.Memory)
   }
-
-  if (validationResult.errors!.length == 0) {
-    validationResult.errors = undefined;
-  };
 
   return validationResult;
 };

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -156,29 +156,30 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   return validationResult;
 };
 
-export function buildErrorMessages(validationResult: ValidationResults): { [key: number]: string } {
-  var errorMessages: { [key: number]: string } = {};
+export function buildErrorMessages(validationResult: ValidationResults, errors: ErrorType[]): string[] {
+  const errorMessages: string[] = [];
 
-  for (let error of validationResult.errors) {
-    if (error == ErrorType.FileFormat) {
-      errorMessages[error] = 'Unknown file format, expected FSEQ v2.0';
+  errors.forEach(error => {
+    switch(error) {
+      case ErrorType.InputData:
+        errorMessages.push('An input type of ArrayBuffer or ArrayBufferLike must be provided!');
+        break;
+      case ErrorType.FileFormat:
+        errorMessages.push('Unknown file format, expected FSEQ v2.0');
+        break;
+      case ErrorType.ChannelCount:
+        errorMessages.push(`Expected 48 channels, got ${validationResult.channelCount}`);
+        break;
+      case ErrorType.FseqType:
+        errorMessages.push('Expected file format to be V2 Uncompressed');
+        break;
+      case ErrorType.Duration:
+        errorMessages.push(`Expected total duration to be less than 5 minutes, got ${new Date(validationResult.duration).toISOString().substr(11, 12)}`);
+        break;
+      case ErrorType.Memory:
+        errorMessages.push(`Used ${parseFloat((validationResult.memoryUsage * 100).toFixed(2))}% of available memory! Sequence uses ${validationResult.commandCount} commands, but the maximum allowed is ${MEMORY_LIMIT}!`);
     }
-    else if (error == ErrorType.ChannelCount) {
-      errorMessages[error] = `Expected 48 channels, got ${validationResult.channelCount}.`;
-    }
-    else if (error == ErrorType.FseqType) {
-      errorMessages[error] = 'Expected file format (FSEQ Version) to be V2 Uncompressed';
-    }
-    else if (error == ErrorType.Duration) {
-      const durationStr = new Date(validationResult.duration).toISOString().substr(11, 12);
-      errorMessages[error] = `Expected total duration to be less than 5 minutes, got ${durationStr}`;
-    }
-    else if (error == ErrorType.Memory) {
-      const memoryUsageFormatted = parseFloat((validationResult.memoryUsage * 100).toFixed(2));
-      const memError = `Used ${memoryUsageFormatted}% of available memory! Sequence uses ${validationResult.commandCount} commands, but the maximum allowed is ${MEMORY_LIMIT}!`;
-      errorMessages[error] = memError
-    };
-  };
+  });
 
   return errorMessages;
 }

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -19,8 +19,7 @@ export class ValidationCheckResults {
 
 /**
  * Validation result type
- * Validation result is considered valid if error field is undefined
- * If the error field is specified, an error message will be built and the validation should be considered invalid
+ * Validation result is considered valid if `isValid` on the ValidationCheckResults of each element in `results` is true.
  * Other fields, if available, are returned to aid in building detailed errors or descriptions
  * @typedef {Object} ValidationResults - creates a new type named 'ValidationResults'
  * @property {number} [frameCount=0] - number of frames
@@ -28,7 +27,7 @@ export class ValidationCheckResults {
  * @property {number} [duration=0] - duration in milliseconds
  * @property {number} [commandCount=0] - number of commands, maximum being 681. commandCount / 681 = memoryUsage
  * @property {number} [stepTime=0] - duration between frames
- * @property {(string | undefined)} [error=undefined] - error message, validation invalid if defined, valid if undefined
+ * @property {{ [key: number]: ValidationCheckResults }} [results=[]] - results of each check that was performed
  */
 export type ValidationResults = {
   frameCount: number;

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -156,10 +156,10 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   return validationResult;
 };
 
-export function buildErrorMessages(validationResult: ValidationResults, errors: ErrorType[]): string[] {
+export function buildErrorMessages(validationResult: ValidationResults): string[] {
   const errorMessages: string[] = [];
 
-  errors.forEach(error => {
+  validationResult.errors.forEach(error => {
     switch(error) {
       case ErrorType.InputData:
         errorMessages.push('An input type of ArrayBuffer or ArrayBufferLike must be provided!');

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -17,9 +17,9 @@ export enum ErrorType {
  * @property {number} [duration=0] - duration in milliseconds
  * @property {number} [commandCount=0] - number of commands, maximum being 681. commandCount / 681 = memoryUsage
  * @property {number} [stepTime=0] - duration between frames
- * @property {ErrorType[]} [errors=[]] - If length > 0, contains the errors that were found. If it empty, the validation result is valid.
+ * @property {ErrorType[]} [errors=[]] - If length > 0, contains the errors that were found. If it's empty, the validation result is valid.
  */
- export type ValidationResults = {
+export type ValidationResults = {
   frameCount: number;
   memoryUsage: number;
   duration: number;
@@ -43,7 +43,7 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
     stepTime: 0,
     channelCount: 0,
     errors: [],
-  }
+  };
 
   if(!data) {
     validationResult.errors.push(ErrorType.InputData);
@@ -71,22 +71,22 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
 
   if(magic !== 'PSEQ' || start < 24 || validationResult.frameCount < 1 || validationResult.stepTime < 15 || minor !== 0 || major !== 2) {
     validationResult.errors.push(ErrorType.FileFormat);
-    return validationResult
+    return validationResult;
   }
 
   if(chCount !== 48) {
-    validationResult.errors.push(ErrorType.ChannelCount)
+    validationResult.errors.push(ErrorType.ChannelCount);
     return validationResult;
   }
 
   if(compressionType !== 0) {
-    validationResult.errors.push(ErrorType.FseqType)
+    validationResult.errors.push(ErrorType.FseqType);
     return validationResult;
   }
 
   validationResult.duration = (validationResult.frameCount * validationResult.stepTime);
   if(validationResult.duration > 5 * 60 * 1000) {
-    validationResult.errors.push(ErrorType.Duration)
+    validationResult.errors.push(ErrorType.Duration);
   }
 
   let prevLight: number[] = [];
@@ -144,7 +144,7 @@ export default (data: ArrayBuffer | ArrayBufferLike): ValidationResults => {
   validationResult.memoryUsage = validationResult.commandCount / MEMORY_LIMIT;
 
   if(validationResult.memoryUsage > 1) {
-    validationResult.errors.push(ErrorType.Memory)
+    validationResult.errors.push(ErrorType.Memory);
   }
 
   return validationResult;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,16 +4,16 @@ import Validator, {ValidationResults} from './Validator';
 
 const validation: ValidationResults = Validator(fs.readFileSync(process.argv[2]).buffer);
 
-let anyErrorExist = false;
+let anyErrorExists = false;
 for (const key in validation.results) {
   const result = validation.results[key];
   if (result.isValid == false) {
     console.error('VALIDATION ERROR:', result.message);
-    anyErrorExist = true;
+    anyErrorExists = true;
   }
 }
 
-if (!anyErrorExist) {
+if (!anyErrorExists) {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
   const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2))
   console.log(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
-import Validator, {ValidationResults, buildErrorMessages} from './Validator';
+import Validator, { ValidationResults, buildErrorMessages } from './Validator';
 
 const file = fs.readFileSync(process.argv[2]);
 const fileArrayBuffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
@@ -9,12 +9,13 @@ const validation: ValidationResults = Validator(fileArrayBuffer);
 if (validation.errors.length > 0) {
 	const errorMessages = buildErrorMessages(validation);
 
-	for (let message of Object.values(errorMessages)) {
+	errorMessages.forEach(message => {
 		console.error('VALIDATION ERROR:', message);
-	};
+	});
+
 } else {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
   const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2));
   console.log(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);
   console.log(`Used ${memoryUsage}% of the available memory`);
-};
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,15 +7,12 @@ const fileArrayBuffer = file.buffer.slice(file.byteOffset, file.byteOffset + fil
 const validation: ValidationResults = Validator(fileArrayBuffer);
 
 if (validation.errors.length > 0) {
-	const errorMessages = buildErrorMessages(validation);
-
-	errorMessages.forEach(message => {
+  buildErrorMessages(validation).forEach(message => {
 		console.error('VALIDATION ERROR:', message);
 	});
-
 } else {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
   const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2));
-  console.log(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);
-  console.log(`Used ${memoryUsage}% of the available memory`);
+  console.info(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);
+  console.info(`Used ${memoryUsage}% of the available memory`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,21 +1,20 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
-import Validator, {ValidationResults} from './Validator';
+import Validator, {ValidationResults, buildErrorMessages} from './Validator';
 
-const validation: ValidationResults = Validator(fs.readFileSync(process.argv[2]).buffer);
+const file = fs.readFileSync(process.argv[2]);
+const fileArrayBuffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+const validation: ValidationResults = Validator(fileArrayBuffer);
 
-let anyErrorExists = false;
-for (const key in validation.results) {
-  const result = validation.results[key];
-  if (result.isValid == false) {
-    console.error('VALIDATION ERROR:', result.message);
-    anyErrorExists = true;
-  }
-}
+if (validation.errors.length > 0) {
+	const errorMessages = buildErrorMessages(validation);
 
-if (!anyErrorExists) {
+	for (let message of Object.values(errorMessages)) {
+		console.error('VALIDATION ERROR:', message);
+	};
+} else {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
-  const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2))
+  const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2));
   console.log(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);
   console.log(`Used ${memoryUsage}% of the available memory`);
-}
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
-import Validator, {ValidationResults} from "./Validator";
+import Validator, {ValidationResults} from './Validator';
 
 const validation: ValidationResults = Validator(fs.readFileSync(process.argv[2]).buffer);
 
-if(validation.error) {
-  console.error('VALIDATION ERROR:', validation.error);
-  process.exit(1);
-} else {
+var anyErrorExist = false;
+for (let key in validation.results) {
+  const result = validation.results[key];
+  if (result.isValid == false) {
+    console.error('VALIDATION ERROR:', result.message);
+    anyErrorExist = true;
+  };
+};
+
+if (!anyErrorExist) {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);
   const memoryUsage = parseFloat((validation.memoryUsage * 100).toFixed(2))
   console.log(`Found ${validation.frameCount} frames, step time of ${validation.stepTime} ms for a total duration of ${durationFormatted}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,14 +4,14 @@ import Validator, {ValidationResults} from './Validator';
 
 const validation: ValidationResults = Validator(fs.readFileSync(process.argv[2]).buffer);
 
-var anyErrorExist = false;
-for (let key in validation.results) {
+let anyErrorExist = false;
+for (const key in validation.results) {
   const result = validation.results[key];
   if (result.isValid == false) {
     console.error('VALIDATION ERROR:', result.message);
     anyErrorExist = true;
-  };
-};
+  }
+}
 
 if (!anyErrorExist) {
   const durationFormatted = new Date(validation.duration * 1000).toISOString().substr(11, 12);

--- a/test/Validator.test.ts
+++ b/test/Validator.test.ts
@@ -1,33 +1,31 @@
 import type { ValidationResults } from "../src/Validator";
-import { ValidationPart } from "../src/Validator";
+import { ErrorType } from "../src/Validator";
 import { Validator } from '../src/index'
 import * as fs from 'fs';
 import * as path from 'path';
 
-function readFile(filePath: string) {
+function readFile(filePath: string): Buffer {
   return fs.readFileSync(path.join(__dirname, filePath));
 }
 
-function readFileAsBuffer(filePath: string) {
-  const file = readFile(filePath);
-  const fileBuffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+function convertBufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
+  const fileBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
   return fileBuffer;
 }
 
 describe('Validator', () => {
   describe('Valid', () => {
     it('should execute validation (valid)', () => {
-      const validationResult: ValidationResults = Validator(readFileAsBuffer('sampleFiles/lightshow_valid.fseq'));
-      expect(Object.keys(validationResult).length).toBe(6);
+      const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(readFile('sampleFiles/lightshow_valid.fseq')));
+      expect(Object.keys(validationResult).length).toBe(7);
       expect(validationResult.frameCount).toBe(2247);
       expect(validationResult.stepTime).toBe(20);
       expect(validationResult.duration).toBe(44940);
       expect(validationResult.memoryUsage).toBeGreaterThan(0.16);
       expect(validationResult.memoryUsage).toBeLessThan(0.17);
       expect(validationResult.commandCount).toBe(112);
-      for (const key in validationResult.results) {
-        expect(validationResult.results[key].isValid).toBe(true)
-      }
+      expect(validationResult.channelCount).toBe(48);
+      expect(validationResult.errors.length).toBe(0)
     });
   });
 
@@ -36,137 +34,122 @@ describe('Validator', () => {
       it('should return error (no data)', () => {
         // @ts-ignore
         const validationResult: ValidationResults = Validator();
-        expect(validationResult.commandCount).toEqual(0);
-        expect(validationResult.duration).toEqual(0);
-        expect(validationResult.frameCount).toEqual(0);
-        expect(validationResult.memoryUsage).toEqual(0);
-        expect(validationResult.stepTime).toEqual(0);
-
-        const resultsKey = ValidationPart.InputData
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('An input type of ArrayBuffer or ArrayBufferLike must be provided!');
+        expect(validationResult).toEqual({
+          errors: [ErrorType.InputData],
+          commandCount: 0,
+          duration: 0,
+          frameCount: 0,
+          memoryUsage: 0,
+          stepTime: 0,
+          channelCount: 0,
+        });
       });
 
       it('should return error (unknown \'magic\' format)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[0] = 79;
-        const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult.commandCount).toEqual(0);
-        expect(validationResult.duration).toEqual(0);
-        expect(validationResult.frameCount).toEqual(2247);
-        expect(validationResult.memoryUsage).toEqual(0);
-        expect(validationResult.stepTime).toEqual(20);
-
-        const resultsKey = ValidationPart.FileFormat
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Unknown file format, expected FSEQ v2.0');
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(buffer));
+        expect(validationResult).toEqual({
+          errors: [ErrorType.FileFormat],
+          commandCount: 0,
+          duration: 0,
+          frameCount: 2247,
+          memoryUsage: 0,
+          stepTime: 20,
+          channelCount: 48,
+        });
       });
 
       it('should return error (not 48 channels)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[11] = 79;
-        const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult.commandCount).toEqual(0);
-        expect(validationResult.duration).toEqual(0);
-        expect(validationResult.frameCount).toEqual(2247);
-        expect(validationResult.memoryUsage).toEqual(0);
-        expect(validationResult.stepTime).toEqual(20);
-
-        const resultsKey = ValidationPart.ChannelCount
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Expected 48 channels, got 20272');
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(buffer));
+        expect(validationResult).toEqual({
+          errors: [ErrorType.ChannelCount],
+          commandCount: 0,
+          duration: 0,
+          frameCount: 2247,
+          memoryUsage: 0,
+          stepTime: 20,
+          channelCount: 20272,
+        });
       });
 
       it('should return error (compressionType=1)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[20] = 3;
-        const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult.commandCount).toEqual(0);
-        expect(validationResult.duration).toEqual(0);
-        expect(validationResult.frameCount).toEqual(2247);
-        expect(validationResult.memoryUsage).toEqual(0);
-        expect(validationResult.stepTime).toEqual(20);
-
-        const resultsKey = ValidationPart.FseqType
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Expected file format to be V2 Uncompressed');
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(buffer));
+        expect(validationResult).toEqual({
+          errors: [ErrorType.FseqType],
+          commandCount: 0,
+          duration: 0,
+          frameCount: 2247,
+          memoryUsage: 0,
+          stepTime: 20,
+          channelCount: 48,
+        });
       });
 
       it('should return error (duration > 5m)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[18] = 255;
-        const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult.commandCount).toEqual(112);
-        expect(validationResult.duration).toEqual(572985);
-        expect(validationResult.frameCount).toEqual(2247);
-        expect(validationResult.memoryUsage).toEqual(0.1644640234948605);
-        expect(validationResult.stepTime).toEqual(255);
-
-        const resultsKey = ValidationPart.Duration
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Expected total duration to be less than 5 minutes, got 00:09:32.985');
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(buffer));
+        expect(validationResult).toEqual({
+          errors: [ErrorType.Duration],
+          commandCount: 112,
+          duration: 572985,
+          frameCount: 2247,
+          memoryUsage: 0.1644640234948605,
+          stepTime: 255,
+          channelCount: 48,
+        });
       });
     });
 
     describe('Memory and Duration', () => {
       it('should execute validation (memory > 100%)', () => {
-        const validationResult: ValidationResults = Validator(readFileAsBuffer('sampleFiles/lightshow_mem_111.fseq'));
-        expect(Object.keys(validationResult).length).toBe(6);
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(readFile('sampleFiles/lightshow_mem_111.fseq')));
+        expect(Object.keys(validationResult).length).toBe(7);
         expect(validationResult.frameCount).toBe(4310);
         expect(validationResult.stepTime).toBe(20);
         expect(validationResult.duration).toBe(86200);
         expect(validationResult.memoryUsage).toBeGreaterThan(1.11);
         expect(validationResult.memoryUsage).toBeLessThan(1.12);
         expect(validationResult.commandCount).toBe(756);
-
-        const resultsKey = ValidationPart.Memory
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Used 111.01% of available memory! Sequence uses 756 commands, but the maximum allowed is 681!');
+        expect(validationResult.channelCount).toBe(48);
+        expect(validationResult.errors.length).toBe(1)
+        expect(validationResult.errors).toContain(ErrorType.Memory)
       });
 
       it('should execute validation (memory > 100%) #2', () => {
-        const validationResult: ValidationResults = Validator(readFileAsBuffer('sampleFiles/lightshow_mem_174.fseq'));
-        expect(Object.keys(validationResult).length).toBe(6);
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(readFile('sampleFiles/lightshow_mem_174.fseq')));
+        expect(Object.keys(validationResult).length).toBe(7);
         expect(validationResult.frameCount).toBe(3093);
         expect(validationResult.stepTime).toBe(50);
         expect(validationResult.duration).toBe(154650);
         expect(validationResult.memoryUsage).toBeGreaterThan(1);
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
-
-        const resultsKey = ValidationPart.Memory
-        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
-        expect(validationResult.results[resultsKey].isValid).toBe(false);
-        expect(validationResult.results[resultsKey].message).toBe('Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!');
+        expect(validationResult.channelCount).toBe(48);
+        expect(validationResult.errors.length).toBe(1)
+        expect(validationResult.errors).toContain(ErrorType.Memory)
       });
 
       it('should execute validation (memory > 100%, duration > 5m)', () => {
         const buffer = readFile('sampleFiles/lightshow_mem_174.fseq');
         buffer[18] = 255;
-        const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(Object.keys(validationResult).length).toBe(6);
+        const validationResult: ValidationResults = Validator(convertBufferToArrayBuffer(buffer));
+        expect(Object.keys(validationResult).length).toBe(7);
         expect(validationResult.frameCount).toBe(3093);
         expect(validationResult.stepTime).toBe(255);
         expect(validationResult.duration).toBe(788715);
         expect(validationResult.memoryUsage).toBeGreaterThan(1.7410);
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
-
-        const firstResultsKey = ValidationPart.Memory
-        expect(Object.keys(validationResult.results)).toContain(firstResultsKey.toString())
-        expect(validationResult.results[firstResultsKey].isValid).toBe(false);
-        expect(validationResult.results[firstResultsKey].message).toBe('Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!');
-
-        const secondResultsKey = ValidationPart.Duration
-        expect(Object.keys(validationResult.results)).toContain(secondResultsKey.toString())
-        expect(validationResult.results[secondResultsKey].isValid).toBe(false);
-        expect(validationResult.results[secondResultsKey].message).toBe('Expected total duration to be less than 5 minutes, got 00:13:08.715');
+        expect(validationResult.channelCount).toBe(48)
+        expect(validationResult.errors.length).toBe(2);
+        expect(validationResult.errors).toContain(ErrorType.Duration);
+        expect(validationResult.errors).toContain(ErrorType.Memory);
       });
     });
   });

--- a/test/Validator.test.ts
+++ b/test/Validator.test.ts
@@ -25,7 +25,7 @@ describe('Validator', () => {
       expect(validationResult.memoryUsage).toBeLessThan(0.17);
       expect(validationResult.commandCount).toBe(112);
       expect(validationResult.channelCount).toBe(48);
-      expect(validationResult.errors.length).toBe(0)
+      expect(validationResult.errors.length).toBe(0);
     });
   });
 
@@ -117,8 +117,8 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeLessThan(1.12);
         expect(validationResult.commandCount).toBe(756);
         expect(validationResult.channelCount).toBe(48);
-        expect(validationResult.errors.length).toBe(1)
-        expect(validationResult.errors).toContain(ErrorType.Memory)
+        expect(validationResult.errors.length).toBe(1);
+        expect(validationResult.errors).toContain(ErrorType.Memory);
       });
 
       it('should execute validation (memory > 100%) #2', () => {
@@ -131,8 +131,8 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
         expect(validationResult.channelCount).toBe(48);
-        expect(validationResult.errors.length).toBe(1)
-        expect(validationResult.errors).toContain(ErrorType.Memory)
+        expect(validationResult.errors.length).toBe(1);
+        expect(validationResult.errors).toContain(ErrorType.Memory);
       });
 
       it('should execute validation (memory > 100%, duration > 5m)', () => {
@@ -146,7 +146,7 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeGreaterThan(1.7410);
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
-        expect(validationResult.channelCount).toBe(48)
+        expect(validationResult.channelCount).toBe(48);
         expect(validationResult.errors.length).toBe(2);
         expect(validationResult.errors).toContain(ErrorType.Duration);
         expect(validationResult.errors).toContain(ErrorType.Memory);

--- a/test/Validator.test.ts
+++ b/test/Validator.test.ts
@@ -9,8 +9,7 @@ function readFile(filePath: string): Buffer {
 }
 
 function convertBufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
-  const fileBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
-  return fileBuffer;
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 }
 
 describe('Validator', () => {
@@ -32,6 +31,7 @@ describe('Validator', () => {
   describe('Invalid', () => {
     describe('Bad Input', () => {
       it('should return error (no data)', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const validationResult: ValidationResults = Validator();
         expect(validationResult).toEqual({

--- a/test/Validator.test.ts
+++ b/test/Validator.test.ts
@@ -1,4 +1,5 @@
 import type { ValidationResults } from "../src/Validator";
+import { ValidationPart } from "../src/Validator";
 import { Validator } from '../src/index'
 import * as fs from 'fs';
 import * as path from 'path';
@@ -24,7 +25,9 @@ describe('Validator', () => {
       expect(validationResult.memoryUsage).toBeGreaterThan(0.16);
       expect(validationResult.memoryUsage).toBeLessThan(0.17);
       expect(validationResult.commandCount).toBe(112);
-      expect(validationResult.error).toBeUndefined();
+      for (const key in validationResult.results) {
+        expect(validationResult.results[key].isValid).toBe(true)
+      }
     });
   });
 
@@ -33,71 +36,80 @@ describe('Validator', () => {
       it('should return error (no data)', () => {
         // @ts-ignore
         const validationResult: ValidationResults = Validator();
-        expect(validationResult).toEqual({
-          error: 'An input type of ArrayBuffer or ArrayBufferLike must be provided!',
-          commandCount: 0,
-          duration: 0,
-          frameCount: 0,
-          memoryUsage: 0,
-          stepTime: 0,
-        });
+        expect(validationResult.commandCount).toEqual(0);
+        expect(validationResult.duration).toEqual(0);
+        expect(validationResult.frameCount).toEqual(0);
+        expect(validationResult.memoryUsage).toEqual(0);
+        expect(validationResult.stepTime).toEqual(0);
+
+        const resultsKey = ValidationPart.InputData
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('An input type of ArrayBuffer or ArrayBufferLike must be provided!');
       });
 
       it('should return error (unknown \'magic\' format)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[0] = 79;
         const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult).toEqual({
-          error: 'Unknown file format, expected FSEQ v2.0',
-          commandCount: 0,
-          duration: 0,
-          frameCount: 2247,
-          memoryUsage: 0,
-          stepTime: 20,
-        });
+        expect(validationResult.commandCount).toEqual(0);
+        expect(validationResult.duration).toEqual(0);
+        expect(validationResult.frameCount).toEqual(2247);
+        expect(validationResult.memoryUsage).toEqual(0);
+        expect(validationResult.stepTime).toEqual(20);
+
+        const resultsKey = ValidationPart.FileFormat
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Unknown file format, expected FSEQ v2.0');
       });
 
       it('should return error (not 48 channels)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[11] = 79;
         const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult).toEqual({
-          error: 'Expected 48 channels, got 20272',
-          commandCount: 0,
-          duration: 0,
-          frameCount: 2247,
-          memoryUsage: 0,
-          stepTime: 20,
-        });
+        expect(validationResult.commandCount).toEqual(0);
+        expect(validationResult.duration).toEqual(0);
+        expect(validationResult.frameCount).toEqual(2247);
+        expect(validationResult.memoryUsage).toEqual(0);
+        expect(validationResult.stepTime).toEqual(20);
+
+        const resultsKey = ValidationPart.ChannelCount
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Expected 48 channels, got 20272');
       });
 
       it('should return error (compressionType=1)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[20] = 3;
         const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult).toEqual({
-          error: 'Expected file format to be V2 Uncompressed',
-          commandCount: 0,
-          duration: 0,
-          frameCount: 2247,
-          memoryUsage: 0,
-          stepTime: 20,
-        });
+        expect(validationResult.commandCount).toEqual(0);
+        expect(validationResult.duration).toEqual(0);
+        expect(validationResult.frameCount).toEqual(2247);
+        expect(validationResult.memoryUsage).toEqual(0);
+        expect(validationResult.stepTime).toEqual(20);
+
+        const resultsKey = ValidationPart.FseqType
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Expected file format to be V2 Uncompressed');
       });
 
       it('should return error (duration > 5m)', () => {
         const buffer = readFile('sampleFiles/lightshow_valid.fseq');
         buffer[18] = 255;
         const validationResult: ValidationResults = Validator(buffer.buffer);
-        expect(validationResult.error).toBe('Expected total duration to be less than 5 minutes, got 00:09:32.985');
-        expect(validationResult).toEqual({
-          error: 'Expected total duration to be less than 5 minutes, got 00:09:32.985',
-          commandCount: 112,
-          duration: 572985,
-          frameCount: 2247,
-          memoryUsage: 0.1644640234948605,
-          stepTime: 255,
-        });
+        expect(validationResult.commandCount).toEqual(112);
+        expect(validationResult.duration).toEqual(572985);
+        expect(validationResult.frameCount).toEqual(2247);
+        expect(validationResult.memoryUsage).toEqual(0.1644640234948605);
+        expect(validationResult.stepTime).toEqual(255);
+
+        const resultsKey = ValidationPart.Duration
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Expected total duration to be less than 5 minutes, got 00:09:32.985');
       });
     });
 
@@ -111,7 +123,11 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeGreaterThan(1.11);
         expect(validationResult.memoryUsage).toBeLessThan(1.12);
         expect(validationResult.commandCount).toBe(756);
-        expect(validationResult.error).toBe('Used 111.01% of available memory! Sequence uses 756 commands, but the maximum allowed is 681!')
+
+        const resultsKey = ValidationPart.Memory
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Used 111.01% of available memory! Sequence uses 756 commands, but the maximum allowed is 681!');
       });
 
       it('should execute validation (memory > 100%) #2', () => {
@@ -123,7 +139,11 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeGreaterThan(1);
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
-        expect(validationResult.error).toBe('Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!')
+
+        const resultsKey = ValidationPart.Memory
+        expect(Object.keys(validationResult.results)).toContain(resultsKey.toString())
+        expect(validationResult.results[resultsKey].isValid).toBe(false);
+        expect(validationResult.results[resultsKey].message).toBe('Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!');
       });
 
       it('should execute validation (memory > 100%, duration > 5m)', () => {
@@ -137,7 +157,16 @@ describe('Validator', () => {
         expect(validationResult.memoryUsage).toBeGreaterThan(1.7410);
         expect(validationResult.memoryUsage).toBeLessThan(1.7420);
         expect(validationResult.commandCount).toBe(1186);
-        expect(validationResult.error).toBe('Expected total duration to be less than 5 minutes, got 00:13:08.715, Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!')
+
+        const firstResultsKey = ValidationPart.Memory
+        expect(Object.keys(validationResult.results)).toContain(firstResultsKey.toString())
+        expect(validationResult.results[firstResultsKey].isValid).toBe(false);
+        expect(validationResult.results[firstResultsKey].message).toBe('Used 174.16% of available memory! Sequence uses 1186 commands, but the maximum allowed is 681!');
+
+        const secondResultsKey = ValidationPart.Duration
+        expect(Object.keys(validationResult.results)).toContain(secondResultsKey.toString())
+        expect(validationResult.results[secondResultsKey].isValid).toBe(false);
+        expect(validationResult.results[secondResultsKey].message).toBe('Expected total duration to be less than 5 minutes, got 00:13:08.715');
       });
     });
   });

--- a/test/Validator.test.ts
+++ b/test/Validator.test.ts
@@ -8,7 +8,9 @@ function readFile(filePath: string) {
 }
 
 function readFileAsBuffer(filePath: string) {
-  return readFile(filePath).buffer;
+  const file = readFile(filePath);
+  const fileBuffer = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+  return fileBuffer;
 }
 
 describe('Validator', () => {


### PR DESCRIPTION
#### Please note

This was my first time writing JavaScript and TypeScript. I gave my best, but I can't ensure that what I wrote follows the best-practices.

## **Why?**

The validator returns some values to help build detailed descriptions and provides an `error` string. This design doesn't allow for differentiation between different error types. It also doesn't give feedback which checks have succeeded and which have failed. This isn't the best design, as users of this package need to know which part was the one that failed. This pull request provides a fix for that problem.

## **How was it fixed?**

On the updated validator the `error` return value is omitted, instead the validator now returns a field called `results`. The `results` field contains information about the checks that have been performed and if the checked entity is valid or invalid (i.e. if the check was successful or unsuccessful). The messages which were previously given through the `error` value to the caller are still being returned - each single check has a `message` property. Note that the message is sometimes left blank. It probably just helps to look at the code to understand what I changed - but I at least wanted to add a brief description.

## **Changes**
- Validator now returns results of checks
- Updated CLI tool to work with that new return technique
- Updated tests to work with that new return technique

I also adjusted [vue-tlsv](https://github.com/sp4c38/vue-tlsv) to match with those changes. I will create a pull request on that repo too, so that the changes can be reflected. edit: [That's the PR on 'vue-tlsv'](https://github.com/xsorifc28/vue-tlsv/pull/1)

## **What still needs to be done**
- [x] I didn't add documentation for the enum and class I added yet.
